### PR TITLE
feat: Add RDB Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,15 +445,17 @@ dependencies = [
  "libc",
  "redis",
  "redis-module",
+ "serde",
+ "serde_json",
  "skiplist",
  "uuid",
 ]
 
 [[package]]
 name = "redis-module"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52778e421fa5bf7914b79535ec6d4ab58fa9061a47279b5057ccd3e716b3cce"
+checksum = "5fde97356730663eae116656956afb48db5c178221693333585372f50d511f3c"
 dependencies = [
  "bindgen",
  "bitflags",
@@ -487,6 +489,43 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "serde"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.8",
+ "syn 1.0.67",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sha1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ name = "redelay"
 
 [dependencies]
 libc = "0.2"
-redis-module = { version = "0.15.0", features = ["experimental-api"]}
+redis-module = { version = "0.17.0", features = ["experimental-api"]}
 uuid = { version = "0.8", features = ["v4"] }
 skiplist = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 redis = "0.20"

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ make test
 
 ## TODO
 
-- RDB support
-- Create timers after AOF restore
-- Validate commands on receive
-- Cluster support
-- Example with streams
-- Test coverage
+- [x] RDB Support
+- [ ] Create timers after AOF restore
+- [ ] Validate commands on receive
+- [ ] Cluster support
+- [ ] Fix all clippy warnings
+- [ ] Example with streams
+- [ ] Test coverage
+- [ ] Move timer create/update into event module

--- a/src/skiplist_ext.rs
+++ b/src/skiplist_ext.rs
@@ -1,0 +1,95 @@
+use serde::de::SeqAccess;
+use serde::de::Visitor;
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use skiplist::OrderedSkipList;
+use std::fmt;
+use std::marker::PhantomData;
+
+// TODO docstring
+pub fn ser_skiplist<T, S>(skiplist: &OrderedSkipList<T>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: Serialize,
+    S: Serializer,
+{
+    let mut state = serializer.serialize_seq(Some(skiplist.len()))?;
+    for i in skiplist {
+        state.serialize_element(i)?;
+    }
+    state.end()
+}
+
+// TODO docstring
+pub fn de_skiplist<'de, T, D>(deserializer: D) -> Result<OrderedSkipList<T>, D::Error>
+where
+    T: Deserialize<'de> + Ord,
+    D: Deserializer<'de>,
+{
+    struct OrderedSkipListVisitor<T>(PhantomData<fn() -> OrderedSkipList<T>>);
+
+    impl<'de, T> Visitor<'de> for OrderedSkipListVisitor<T>
+    where
+        T: Deserialize<'de> + Ord,
+    {
+        type Value = OrderedSkipList<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a nonempty sequence of tuples")
+        }
+
+        fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+        where
+            S: SeqAccess<'de>,
+        {
+            let mut ret = if let Some(size_hint) = seq.size_hint() {
+                OrderedSkipList::with_capacity(size_hint)
+            } else {
+                OrderedSkipList::new()
+            };
+            while let Some(t) = seq.next_element()? {
+                ret.insert(t);
+            }
+            Ok(ret)
+        }
+    }
+    let visitor = OrderedSkipListVisitor(PhantomData);
+    deserializer.deserialize_seq(visitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize() {
+        #[derive(Serialize)]
+        struct OrderedSkipListWrapper(
+            #[serde(serialize_with = "ser_skiplist")] OrderedSkipList<(u8, u16, u32)>,
+        );
+
+        let mut list = OrderedSkipList::new();
+        list.insert((10, 10, 10));
+        list.insert((5, 5, 5));
+        list.insert((1, 1, 1));
+
+        let wrapped_list = OrderedSkipListWrapper(list);
+
+        let ser_list = serde_json::to_string(&wrapped_list).unwrap();
+        assert_eq!(ser_list, "[[1,1,1],[5,5,5],[10,10,10]]");
+    }
+
+    #[test]
+    fn deserialize() {
+        #[derive(Deserialize)]
+        struct OrderedSkipListWrapper(
+            #[serde(deserialize_with = "de_skiplist")] OrderedSkipList<(u8, u16, u32)>,
+        );
+
+        let mut wrapped_list: OrderedSkipListWrapper =
+            serde_json::from_str("[[1,1,1],[5,5,5],[10,10,10]]").unwrap();
+        assert_eq!(wrapped_list.0.pop_front(), Some((1, 1, 1)));
+        assert_eq!(wrapped_list.0.pop_front(), Some((5, 5, 5)));
+        assert_eq!(wrapped_list.0.pop_front(), Some((10, 10, 10)));
+        assert_eq!(wrapped_list.0.pop_front(), None);
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,5 @@
 use std::time::Duration;
 
-use redis;
-
 #[test]
 #[cfg_attr(not(feature = "integration_tests"), ignore)]
 // Creates a schedule that inserts a list into a list every second.
@@ -62,6 +60,73 @@ fn test_populating_fifo() -> redis::RedisResult<()> {
         .arg("test-schedule")
         .query(&mut con)?;
     assert_eq!(schedule.len(), 0);
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(not(feature = "integration_tests"), ignore)]
+// Create a schedule in Redis and dump it.
+// Restore the dump into another key
+// Both keys should have the same content
+//
+// Wait for a few seconds and expect duplicated items in the list
+fn test_rdb_support() -> redis::RedisResult<()> {
+    let client = redis::Client::open("redis://127.0.0.1:6666/")?;
+    let mut con = client.get_connection()?;
+
+    redis::pipe()
+        .cmd("DEL")
+        .arg("test-rdb-orig")
+        .arg("test-rdb-dest")
+        .arg("test-rdb-list")
+        .query(&mut con)?;
+
+    redis::pipe()
+        // delay item-1
+        .cmd("SCHEDULE.ADD")
+        .arg("test-rdb-orig")
+        .arg(3)
+        .arg("rpush")
+        .arg("test-rdb-list")
+        .arg("item-1")
+        // delay item-2
+        .cmd("SCHEDULE.ADD")
+        .arg("test-rdb-orig")
+        .arg(4)
+        .arg("rpush")
+        .arg("test-rdb-list")
+        .arg("item-2")
+        .query(&mut con)?;
+
+    let orig: Vec<u8> = redis::cmd("DUMP").arg("test-rdb-orig").query(&mut con)?;
+
+    redis::cmd("RESTORE")
+        .arg("test-rdb-dest")
+        .arg(0)
+        .arg(orig.as_slice())
+        .query(&mut con)?;
+
+    let orig: Vec<Vec<String>> = redis::cmd("SCHEDULE.SCAN")
+        .arg("test-rdb-orig")
+        .query(&mut con)?;
+
+    let dest: Vec<Vec<String>> = redis::cmd("SCHEDULE.SCAN")
+        .arg("test-rdb-dest")
+        .query(&mut con)?;
+
+    assert_eq!(orig, dest);
+
+    std::thread::sleep(Duration::from_secs(4));
+    let final_list: Vec<String> = redis::cmd("LRANGE")
+        .arg("test-rdb-list")
+        .arg(0)
+        .arg(-1)
+        .query(&mut con)?;
+
+    assert_eq!(final_list.len(), 4);
+    assert_eq!(final_list.iter().filter(|x| *x == "item-1").count(), 2);
+    assert_eq!(final_list.iter().filter(|x| *x == "item-2").count(), 2);
 
     Ok(())
 }


### PR DESCRIPTION
- Use serde to serialize/deserialize rdb
- Implement serializer/deserializer for skiplist
- Implement rdb load and save in the module
- Create timers on rdb loading (still need redis-modules support for
  LOADED events)